### PR TITLE
Fix inconsistent use of quotes in card_response.py

### DIFF
--- a/sc_tools/card_response.py
+++ b/sc_tools/card_response.py
@@ -125,5 +125,5 @@ class CardResponseError(Exception):
             self.status = CardResponseStatus(response_status)
         else:
             self.status = response_status
-        self.message = f"The card returned {format(self.status.sw, "04X")} ({self.status.status_type().name})."
+        self.message = f"The card returned {format(self.status.sw, '04X')} ({self.status.status_type().name})."
         super().__init__(self.message)


### PR DESCRIPTION
This merge request addresses the inconsistent use of quotes in the `card_response.py` file. Specifically, it changes the double quotes to single quotes in the formatted string for the `self.message` attribute to ensure consistency.

**Changes:**
- Changed double quotes to single quotes in the formatted string for the `self.message` attribute.

**Reason for Change:**
- To maintain consistency in the use of single quotes for string literals throughout the codebase.

**Testing:**
- Verified that the change does not affect the functionality of the code.
