### PR TITLE
Fix validation error in ScExplorerCli class

### DIFF
--- a/sc_explorer_cli/sc_explorer_cli.py
+++ b/sc_explorer_cli/sc_explorer_cli.py
@@ -311,8 +311,8 @@ class ScExplorerCli:
             Self: This instance
         """
 
-        if key is not None and not isinstance(key, str):
-            raise ValueError("Argument `key` must be str.")
+        if key is not None and not (isinstance(key, str) or isinstance(key, int)):
+            raise ValueError("Argument `key` must be str or int.")
         if not isinstance(cla, int):
             raise ValueError("Argument `cla` must be int.")
 


### PR DESCRIPTION
This pull request fixes a validation error in the `ScExplorerCli` class. Previously, the `key` argument was only allowed to be a string, but now it can also be an integer. This permits digit PIN.

Note: argument validation or runtime type enforcing (not to be confused with static type checking) should be done with smarter way in the future.